### PR TITLE
fix select de elementos por página en Overview no respeta la selecció…

### DIFF
--- a/ui/src/views/App/Overview/SLOOverview.tsx
+++ b/ui/src/views/App/Overview/SLOOverview.tsx
@@ -143,7 +143,11 @@ const SLOTable: React.FC<IProps> = ({ ...props }) => {
 			<Table
 				dataSource={tableData}
 				columns={tableColumns(props)}
-				pagination={{ pageSize: 15 }}
+				pagination={{
+					defaultPageSize: 15,
+					showSizeChanger: true,
+					pageSizeOptions: ['10', '15', '20', '50', '100'],
+				}}
 				size="middle"
 				style={{ width: "auto", margin: "0 2em" }}
 			/>


### PR DESCRIPTION
# [Description]
## What does this pull do?
Corrige el bug reportado en el ticket #17588: el selector de "elementos por página" en la vista Overview no respetaba la cantidad elegida por el usuario, siempre volvía a mostrar 15 resultados. La causa era que `pagination` se pasaba con un `pageSize` fijo en cada render, en modo controlado, sin lógica para actualizarlo. Se cambió a `defaultPageSize` (modo no controlado), se agregó `showSizeChanger: true` explícito, y se incluyó "15" en las opciones seleccionables del dropdown.

## What kind of changes do it do
Please delete options that are not relevant.
- [x] BUG ( change which fixes an issue )

## Need any DB Migrations?
- [x] No

## How have you tested this
- [x] Yes

Probado en local con docker-compose, cargando ~65 sucursales de prueba (necesario para superar el umbral de 50 registros que activa el selector de tamaño de página en Ant Design). Se reprodujo el bug (elegir "50/page" → cambiar de mes → volvía a 15) y se confirmó el fix (se mantiene el tamaño elegido).

## This change requires a documentation update?
- [x] No

## Code Checklist
- [x] Build passed
- [x] My changes generate no new warnings
- [x] Manually Tested
- [x] Rebased with master/upto date with master

## TODO
- [x] N/A — cambio acotado a una sola línea de configuración, no requiere breakdown adicional

## Pre-Merge Checklist
- [x] I have **Labeled** my PR
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation or raised against changes to the concerned person ( please mention here ) — N/A, no aplica documentación externa
- [x] Any dependent changes have been merged and published — N/A, sin dependencias