### PR TITLE
fix deshabilitar descarga de CSV mientras se actualizan los datos del…

### DIFF
--- a/ui/src/views/App/Overview/SLOOverview.tsx
+++ b/ui/src/views/App/Overview/SLOOverview.tsx
@@ -67,7 +67,7 @@ const tableColumns = (props) => [
 	},
 ];
 
-const DownloadCSVButton = ({ data, yearMonth }: { data: any[]; yearMonth: string }) => {
+const DownloadCSVButton = ({ data, yearMonth, disabled }: { data: any[]; yearMonth: string; disabled?: boolean }) => {
   const downloadCSV = () => {
 	const headers = [
 	  "SLO Name",
@@ -102,7 +102,7 @@ const DownloadCSVButton = ({ data, yearMonth }: { data: any[]; yearMonth: string
   };
 
   return (
-    <Button type="primary" onClick={downloadCSV}>
+    <Button type="primary" onClick={downloadCSV} disabled={disabled}>
       Download CSV
     </Button>
   );
@@ -114,7 +114,7 @@ const SLOTable: React.FC<IProps> = ({ ...props }) => {
 		setSelectedMonth(value ?? moment());
 	  };
 
-	const { overview } = useGetOverview(
+	const { overview, loading } = useGetOverview(
 		selectedMonth ? selectedMonth.format('YYYY-MM') : undefined
 	);
 
@@ -138,11 +138,13 @@ const SLOTable: React.FC<IProps> = ({ ...props }) => {
 				<DownloadCSVButton
 					data={tableData}
 					yearMonth={selectedMonth.format("YYYY-MM")}
+					disabled={loading}
 				/>
 			</div>
 			<Table
 				dataSource={tableData}
 				columns={tableColumns(props)}
+				loading={loading}
 				pagination={{ pageSize: 15 }}
 				size="middle"
 				style={{ width: "auto", margin: "0 2em" }}


### PR DESCRIPTION
# [Description]
## What does this pull do?
Corrige el bug reportado en el ticket #17587: al cambiar de mes en la vista Overview, el reporte CSV podía descargarse con datos desactualizados (del mes anterior) mientras el fetch de los datos nuevos todavía estaba en curso. El botón "Download CSV" no tenía forma de saber si los datos ya habían terminado de cargar, por lo que quedaba habilitado incluso mientras la tabla mostraba valores viejos.

Se conectó el estado `loading` (que ya exponía el hook `useGetOverview` pero no se usaba) para: deshabilitar el botón de descarga mientras los datos del mes elegido están cargando, y mostrar el spinner nativo de la tabla (`loading={loading}`) para dar feedback visual claro al usuario.

## What kind of changes do it do
Please delete options that are not relevant.
- [x] BUG ( change which fixes an issue )

## Need any DB Migrations?
- [x] No

## How have you tested this
- [x] Yes

Probado en local con throttling "Slow 3G" en las DevTools (en localhost el fetch es demasiado rápido para notar el bug a simple vista). Se reprodujo el bug (descargar el CSV mientras cargaba el mes nuevo → archivo con nombre del mes nuevo pero datos del mes anterior) y se confirmó el fix (el botón queda deshabilitado y la tabla muestra el spinner mientras carga; la descarga solo es posible una vez que los datos están actualizados).

## This change requires a documentation update?
- [x] No

## Code Checklist
- [x] Build passed
- [x] My changes generate no new warnings
- [x] Manually Tested
- [x] Rebased with master/upto date with master

## TODO
- [x] N/A — cambio acotado, conecta un estado ya existente en el hook, no requiere breakdown adicional

## Pre-Merge Checklist
- [x] I have **Labeled** my PR
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation or raised against changes to the concerned person ( please mention here ) — N/A, no aplica documentación externa
- [x] Any dependent changes have been merged and published — N/A, sin dependencias